### PR TITLE
Add Missing Tests to Boost Coverage Report

### DIFF
--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -91,5 +91,24 @@ describe Merchant, type: :model do
       expect(merchant.invoices_filtered_by_status("returned")).to eq([inv_5_returned])
       expect(other_merchant.invoices_filtered_by_status("packaged")).to eq([inv_4_packaged])
     end
+
+    it "should return the total number of coupons for a merchant" do
+      merchant = create(:merchant)
+      create_list(:coupon, 4, merchant: merchant)  
+    
+      expect(merchant.coupons_count).to eq(4) 
+    end
+
+    it "should return the count of invoices with applied coupons" do
+      merchant = create(:merchant)
+      customer = create(:customer)
+      coupon = create(:coupon, merchant: merchant)
+      
+      create(:invoice, merchant: merchant, customer: customer, coupon: coupon)  # Invoice with coupon
+      create(:invoice, merchant: merchant, customer: customer, coupon: nil)   # Invoice without coupon
+      create(:invoice, merchant: merchant, customer: customer, coupon: coupon)  # Another invoice with a coupon
+    
+      expect(merchant.invoice_coupon_count).to eq(2) # Should return 2 (only invoices with coupons)
+    end
   end
 end


### PR DESCRIPTION
# Pull Request: Adding Missing Model Tests

##  Summary
This PR adds test coverage for previously untested methods in the `Merchant` and `Coupon` models to ensure full test coverage.

##  Tests Added

### Merchant Model Tests:
- **`coupons_count`** → Ensures a merchant correctly counts its total coupons.
- **`invoice_coupon_count`** → Ensures a merchant correctly counts invoices with applied coupons.

### Coupon Model Tests:
- **`toggle_active!`** → Ensures coupons respect the 5 active coupon limit and cannot be deactivated if linked to a pending invoice.
- **`filter_by_status`** → Ensures coupons can be filtered by active or inactive status.

## Why?
- Increased test coverage (validated via SimpleCov).
- Ensures correct functionality of coupon and invoice tracking.
